### PR TITLE
Member fixes

### DIFF
--- a/src/assets/FamilyTree.css
+++ b/src/assets/FamilyTree.css
@@ -106,8 +106,10 @@
 
 .spouse-card:hover {
   opacity: 1;
-  transform: translateX(40px) translateY(-5px);
   z-index: 10 !important;
+  /* highline the card: transform was not working */
+  stroke-width: 3 !important;
+  filter: drop-shadow(0 0 12px rgba(99, 102, 241, 0.6));
 }
 
 .spouse-card rect {

--- a/src/assets/FamilyTree.css
+++ b/src/assets/FamilyTree.css
@@ -85,6 +85,19 @@
   fill: #eef2ff !important;
 }
 
+/* First Member Highlighting */
+.member-card.first-member rect {
+  stroke: #f59e0b !important;
+  stroke-width: 3 !important;
+  filter: drop-shadow(0 0 8px rgba(245, 158, 11, 0.4));
+}
+
+.member-card.first-member:hover rect {
+  stroke: #f59e0b !important;
+  stroke-width: 4 !important;
+  filter: drop-shadow(0 0 12px rgba(245, 158, 11, 0.6));
+}
+
 /* Spouse Cards */
 .spouse-card {
   opacity: 0.7;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -21,6 +21,9 @@ const Dashboard: React.FC = () => {
   const [memberToEdit, setMemberToEdit] = useState<FamilyMember | null>(null);
   const [selectedFamilyMember, setSelectedFamilyMember] = useState<FamilyMember | null>(null);
 
+  // Get the first member created (member with earliest created_at timestamp)
+  const firstMember = familyMembers.length > 0 ? familyMembers[0] : null;
+
   useEffect(() => {
     if (!user) {
       navigate('/login');
@@ -339,6 +342,7 @@ const Dashboard: React.FC = () => {
               }}
               onEditMember={handleEditMember}
               onClosePopup={() => setSelectedFamilyMember(null)}
+              firstMember={firstMember}
             />
         )}
 


### PR DESCRIPTION
[feat: Add first member tracking and centering functionality](https://github.com/Can1Cyp2/Family-Tree-Site/commit/d7fd2dec5afa78cd94b72528bae1f3b8df528e78) 

- Track the first family member created using created_at timestamp
- Auto-center view on first member when tree loads (mobile and desktop)
- Add visual indicators: golden border and '1st' badge for first member
- Add 'Center on First Member' button in controls for easy navigation
- Add legend item explaining first member indicator
- Maintain existing tree layout while adding new functionality
- Handle edge cases and fallback gracefully

This provides better user orientation and navigation in the family tree.