### PR TITLE
feat: Fix mini map visibility and improve spacing

### DIFF
--- a/src/assets/FamilyTree.css
+++ b/src/assets/FamilyTree.css
@@ -4,7 +4,7 @@
   margin: 0 auto;
   position: relative;
   background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-  overflow: hidden; /* Hide scrollbars and prevent scrolling on desktop */
+  overflow: visible; /* Allow mini map to be visible */
   /* Hide scrollbars for all browsers */
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none;  /* IE 10+ */


### PR DESCRIPTION
- Fix mini map not showing due to CSS overflow:hidden clipping
- Add proper dependency array for handleMiniMapClick callback
- Move mini map handlers after treeBounds calculation to avoid scope issues
- Reduce mini map card sizes (8x6 → 6x4 pixels) for better density
- Add compact scaling with 15px padding to reduce spacing between icons
- Update viewport indicator to match compact scaling
- Ensure mini map only shows on desktop (non-mobile) devices

The mini map now displays correctly in bottom-left corner with properly spaced family member icons.