### PR TITLE
Fix/spouses

### DIFF
--- a/src/assets/FamilyTreeModal.css
+++ b/src/assets/FamilyTreeModal.css
@@ -1,0 +1,247 @@
+/* FamilyTreeModal.css */
+
+.family-tree-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 0; /* Remove padding to allow full screen */
+}
+
+.family-tree-modal-content {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  max-width: none; /* Remove max-width constraint */
+  max-height: none; /* Remove max-height constraint */
+  background: white;
+  border-radius: 0; /* Remove border radius for true fullscreen */
+  overflow: hidden;
+  box-shadow: none; /* Remove shadow for fullscreen effect */
+}
+
+.family-tree-modal-close-btn {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid #e5e7eb;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 24px;
+  font-weight: bold;
+  color: #374151;
+  cursor: pointer;
+  z-index: 1001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.family-tree-modal-close-btn:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  transform: scale(1.05);
+}
+
+.family-tree-modal-close-btn:active {
+  transform: scale(0.95);
+}
+
+/* Ensure the family tree component fills the modal */
+.family-tree-modal-content .family-tree-container {
+  width: 100%;
+  height: 100%;
+  border-radius: 0; /* Remove border radius */
+}
+
+/* Override any existing fullscreen styles in the family tree */
+.family-tree-modal-content .family-tree-container.family-tree-fullscreen {
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: auto;
+}
+
+/* Navigation Controls */
+.family-tree-navigation-controls {
+  position: absolute;
+  top: 120px; /* Adjusted for fullscreen */
+  left: 20px;
+  z-index: 1001;
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.navigation-arrows {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+}
+
+.nav-horizontal {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.nav-btn {
+  background: rgba(255, 255, 255, 0.95);
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #374151;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  user-select: none;
+}
+
+.nav-btn:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  transform: scale(1.05);
+}
+
+.nav-btn:active {
+  transform: scale(0.95);
+  background: #e5e7eb;
+}
+
+.nav-btn-center {
+  background: rgba(59, 130, 246, 0.95);
+  border-color: #3b82f6;
+  color: white;
+}
+
+.nav-btn-center:hover {
+  background: rgba(37, 99, 235, 0.95);
+  border-color: #2563eb;
+}
+
+.zoom-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.zoom-btn {
+  background: rgba(16, 185, 129, 0.95);
+  border-color: #10b981;
+  color: white;
+  font-size: 20px;
+}
+
+.zoom-btn:hover {
+  background: rgba(5, 150, 105, 0.95);
+  border-color: #059669;
+}
+
+/* Navigation Instructions */
+.navigation-instructions {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 14px;
+  z-index: 1001;
+  pointer-events: none;
+}
+
+/* Transform container for the family tree */
+.family-tree-transform-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Scale indicator */
+.scale-indicator {
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: bold;
+  min-width: 50px;
+  text-align: center;
+}
+
+/* Scrollable container for the family tree */
+.family-tree-scrollable-container {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+
+/* Ensure controls are visible in modal */
+.family-tree-modal-content .family-tree-controls {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1001;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .family-tree-modal-overlay {
+    padding: 0;
+  }
+  
+  .family-tree-modal-content {
+    border-radius: 0;
+    width: 100vw;
+    height: 100vh;
+  }
+  
+  .family-tree-modal-close-btn {
+    top: 10px;
+    right: 10px;
+    width: 35px;
+    height: 35px;
+    font-size: 20px;
+  }
+
+  .family-tree-navigation-controls {
+    top: 60px;
+    left: 10px;
+    gap: 10px;
+  }
+
+  .nav-btn {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+
+  .navigation-instructions {
+    bottom: 10px;
+    font-size: 11px;
+    padding: 4px 8px;
+  }
+}

--- a/src/components/D3FamilyTree.tsx
+++ b/src/components/D3FamilyTree.tsx
@@ -1,338 +1,294 @@
-import React, { useEffect, useRef, useState } from 'react';
-import FamilyTree from './FamilyTree';
+import React, { useRef, useEffect, useMemo, useImperativeHandle, forwardRef } from 'react';
+import * as d3 from 'd3';
 import { FamilyMember, Relationship } from '../types';
-import '../assets/FamilyTreeModal.css';
+import '../assets/FamilyTree.css';
 
-interface FamilyTreeModalProps {
+interface D3FamilyTreeProps {
   familyMembers: FamilyMember[];
   relationships: Relationship[];
-  onDeleteMember: (memberId: string) => void;
   onSelectMember: (member: FamilyMember) => void;
   selectedMember: FamilyMember | null;
-  onDeleteRelationship: (relationshipId: string) => void;
-  onAddMember: () => void;
-  onAddRelatedMember: (member: FamilyMember) => void;
-  onAddExistingRelationship: (member: FamilyMember) => void;
-  onEditMember: (member: FamilyMember) => void;
-  onClose: () => void;
-  firstMember?: FamilyMember | null;
-  isFullscreen?: boolean;
 }
 
-const FamilyTreeModal: React.FC<FamilyTreeModalProps> = (props) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  // Reduced from 200 to 50 for more controlled movement
-  const MOVE_AMOUNT = 50;
-  // Alternative: You can make it adaptive based on container size
-  // const MOVE_AMOUNT = containerRef.current ? Math.min(containerRef.current.clientWidth * 0.1, 100) : 50;
+interface D3Node {
+  id: string;
+  partners: FamilyMember[];
+  children: D3Node[];
+  x?: number;
+  y?: number;
+  parent?: D3Node;
+}
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        props.onClose();
+export interface D3FamilyTreeRef {
+  panBy: (dx: number, dy: number) => void;
+  zoomBy: (k: number) => void;
+  centerView: () => void;
+}
+
+const D3FamilyTree = forwardRef<D3FamilyTreeRef, D3FamilyTreeProps>(({
+  familyMembers,
+  relationships,
+  onSelectMember,
+  selectedMember
+}, ref) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  // Build D3 hierarchical data structure
+  const treeData = useMemo(() => {
+    // Helper to get a unique key for a couple
+    const coupleKey = (ids: string[]) => ids.sort().join('-');
+    
+    // Find all spouse pairs
+    const spousePairs = new Set<string>();
+    relationships.forEach(rel => {
+      if (rel.relationship_type === 'spouse') {
+        spousePairs.add(coupleKey([rel.person1_id, rel.person2_id]));
       }
-      // Add keyboard navigation - only if not focused on an input/button
-      const activeElement = document.activeElement;
-      const isInputFocused = activeElement && (
-        activeElement.tagName === 'INPUT' || 
-        activeElement.tagName === 'BUTTON' || 
-        activeElement.tagName === 'TEXTAREA'
-      );
-      
-      if (!isInputFocused) {
-        if (event.key === 'ArrowLeft') {
-          event.preventDefault();
-          handleNavigate('left');
-        } else if (event.key === 'ArrowRight') {
-          event.preventDefault();
-          handleNavigate('right');
-        } else if (event.key === 'ArrowUp') {
-          event.preventDefault();
-          handleNavigate('up');
-        } else if (event.key === 'ArrowDown') {
-          event.preventDefault();
-          handleNavigate('down');
+    });
+
+    // Build couple nodes
+    const memberMap = new Map(familyMembers.map(m => [m.id, m]));
+    const coupleNodeMap = new Map<string, D3Node>();
+    const usedMembers = new Set<string>();
+
+    // Create couple nodes
+    spousePairs.forEach(key => {
+      const [id1, id2] = key.split('-');
+      if (memberMap.has(id1) && memberMap.has(id2)) {
+        coupleNodeMap.set(key, {
+          id: key,
+          partners: [memberMap.get(id1)!, memberMap.get(id2)!],
+          children: []
+        });
+        usedMembers.add(id1);
+        usedMembers.add(id2);
+      }
+    });
+
+    // Create single nodes for unpaired members
+    familyMembers.forEach(member => {
+      if (!usedMembers.has(member.id)) {
+        const key = coupleKey([member.id]);
+        coupleNodeMap.set(key, {
+          id: key,
+          partners: [member],
+          children: []
+        });
+      }
+    });
+
+    // Build parent-child relationships
+    relationships.forEach(rel => {
+      if (rel.relationship_type === 'parent') {
+        const parent = memberMap.get(rel.person1_id);
+        const child = memberMap.get(rel.person2_id);
+        if (!parent || !child) return;
+
+        // Find parent couple node
+        let parentNode: D3Node | undefined;
+        Array.from(coupleNodeMap.values()).forEach(node => {
+          if (node.partners.some((p: FamilyMember) => p.id === parent.id)) {
+            parentNode = node;
+          }
+        });
+
+        // Find child couple node
+        let childNode: D3Node | undefined;
+        Array.from(coupleNodeMap.values()).forEach(node => {
+          if (node.partners.some((p: FamilyMember) => p.id === child.id)) {
+            childNode = node;
+          }
+        });
+
+        if (parentNode && childNode && parentNode !== childNode) {
+          parentNode.children.push(childNode);
         }
       }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-
-    // Prevent body scroll when modal is open
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      // Restore body scroll when modal closes
-      document.body.style.overflow = 'unset';
-    };
-  }, [props.onClose]);
-
-  const findFamilyTreeContainer = (): HTMLElement | null => {
-    if (!containerRef.current) return null;
-    return containerRef.current.querySelector('.family-tree-container') as HTMLElement;
-  };
-
-  const triggerPanEvent = (direction: 'left' | 'right' | 'up' | 'down') => {
-    const treeContainer = findFamilyTreeContainer();
-    if (!treeContainer) return;
-
-    const svg = treeContainer.querySelector('svg') as SVGElement;
-    if (!svg) return;
-
-    // Calculate move amount based on container size for better UX
-    const containerRect = treeContainer.getBoundingClientRect();
-    const adaptiveMoveAmount = Math.min(MOVE_AMOUNT, containerRect.width * 0.1);
-
-    let deltaX = 0;
-    let deltaY = 0;
-
-    switch (direction) {
-      case 'left':
-        deltaX = adaptiveMoveAmount;
-        break;
-      case 'right':
-        deltaX = -adaptiveMoveAmount;
-        break;
-      case 'up':
-        deltaY = adaptiveMoveAmount;
-        break;
-      case 'down':
-        deltaY = -adaptiveMoveAmount;
-        break;
-    }
-
-    // Get the center of the SVG
-    const rect = svg.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    // Simulate mouse down, move, and up events to trigger panning
-    const mouseDownEvent = new MouseEvent('mousedown', {
-      clientX: centerX,
-      clientY: centerY,
-      bubbles: true,
-      cancelable: true
     });
 
-    const mouseMoveEvent = new MouseEvent('mousemove', {
-      clientX: centerX + deltaX,
-      clientY: centerY + deltaY,
-      bubbles: true,
-      cancelable: true
-    });
-
-    const mouseUpEvent = new MouseEvent('mouseup', {
-      clientX: centerX + deltaX,
-      clientY: centerY + deltaY,
-      bubbles: true,
-      cancelable: true
-    });
-
-    // Dispatch the events in sequence
-    svg.dispatchEvent(mouseDownEvent);
-    setTimeout(() => {
-      svg.dispatchEvent(mouseMoveEvent);
-      setTimeout(() => {
-        svg.dispatchEvent(mouseUpEvent);
-      }, 10);
-    }, 10);
-
-    console.log('Triggered pan event:', direction, { deltaX, deltaY, adaptiveMoveAmount });
-  };
-
-  const handleNavigate = (direction: 'left' | 'right' | 'up' | 'down') => {
-    triggerPanEvent(direction);
-  };
-
-  const handleCenterView = () => {
-    // Try to find and click the existing "Center on First Member" button first
-    const treeContainer = findFamilyTreeContainer();
-    if (treeContainer) {
-      const buttons = Array.from(treeContainer.querySelectorAll('button'));
-      const centerButton = buttons.find(btn => 
-        btn.textContent?.includes('Center on First Member') ||
-        btn.textContent?.includes('Center') ||
-        btn.title?.includes('Center')
-      );
-
-      if (centerButton) {
-        centerButton.click();
-        console.log('Clicked existing center button');
-        return;
-      }
-
-      // Fallback: Try to find "Reset View" button
-      const resetButton = buttons.find(btn => 
-        btn.textContent?.includes('Reset View') ||
-        btn.textContent?.includes('Reset')
-      );
-
-      if (resetButton) {
-        resetButton.click();
-        console.log('Clicked reset view button');
-        return;
-      }
-    }
-
-    console.log('No center button found');
-  };
-
-  const handleZoomIn = () => {
-    const treeContainer = findFamilyTreeContainer();
-    if (treeContainer) {
-      const buttons = Array.from(treeContainer.querySelectorAll('button'));
-      const zoomInButton = buttons.find(btn => 
-        btn.textContent?.includes('Zoom In')
-      );
-
-      if (zoomInButton) {
-        zoomInButton.click();
-        console.log('Clicked existing zoom in button');
-        return;
-      }
-    }
-
-    // Fallback: Try to trigger wheel event for zoom
-    const svg = treeContainer?.querySelector('svg') as SVGElement;
-    if (svg) {
-      const wheelEvent = new WheelEvent('wheel', {
-        deltaY: -100, // Negative for zoom in
-        bubbles: true,
-        cancelable: true
+    // Find root nodes (those with no parents)
+    const allChildren = new Set<string>();
+    coupleNodeMap.forEach(node => {
+      node.children.forEach(child => {
+        allChildren.add(child.id);
       });
-      svg.dispatchEvent(wheelEvent);
-      console.log('Triggered synthetic wheel event for zoom in');
-    }
-  };
+    });
 
-  const handleZoomOut = () => {
-    const treeContainer = findFamilyTreeContainer();
-    if (treeContainer) {
-      const buttons = Array.from(treeContainer.querySelectorAll('button'));
-      const zoomOutButton = buttons.find(btn => 
-        btn.textContent?.includes('Zoom Out')
-      );
+    const roots: D3Node[] = [];
+    coupleNodeMap.forEach(node => {
+      if (!allChildren.has(node.id)) {
+        roots.push(node);
+      }
+    });
 
-      if (zoomOutButton) {
-        zoomOutButton.click();
-        console.log('Clicked existing zoom out button');
-        return;
+    return roots.length > 0 ? roots[0] : Array.from(coupleNodeMap.values())[0];
+  }, [familyMembers, relationships]);
+
+  // Store references to zoomBehavior, svg, and initialTransform for imperative handle
+  const zoomBehaviorRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(null);
+  const svgD3Ref = useRef<d3.Selection<SVGSVGElement, unknown, null, undefined> | null>(null);
+  const initialTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity.translate(50, 50).scale(1));
+
+  useImperativeHandle(ref, () => ({
+    panBy: (dx: number, dy: number) => {
+      if (svgD3Ref.current && zoomBehaviorRef.current) {
+        svgD3Ref.current.transition().duration(200).call((zoomBehaviorRef.current as any).translateBy, dx, dy);
+      }
+    },
+    zoomBy: (k: number) => {
+      if (svgD3Ref.current && zoomBehaviorRef.current) {
+        const width = 800;
+        const height = 600;
+        const [centerX, centerY] = [width / 2, height / 2];
+        svgD3Ref.current.transition().duration(200).call((zoomBehaviorRef.current as any).scaleBy, k, [centerX, centerY]);
+      }
+    },
+    centerView: () => {
+      if (svgD3Ref.current && zoomBehaviorRef.current) {
+        svgD3Ref.current.transition().duration(750).call((zoomBehaviorRef.current as any).transform, initialTransformRef.current);
       }
     }
+  }));
 
-    // Fallback: Try to trigger wheel event for zoom
-    const svg = treeContainer?.querySelector('svg') as SVGElement;
-    if (svg) {
-      const wheelEvent = new WheelEvent('wheel', {
-        deltaY: 100, // Positive for zoom out
-        bubbles: true,
-        cancelable: true
+  useEffect(() => {
+    if (!svgRef.current || !treeData) return;
+
+    // Clear previous content
+    d3.select(svgRef.current).selectAll("*").remove();
+
+    const svg = d3.select(svgRef.current);
+    svgD3Ref.current = svg;
+    const width = 800;
+    const height = 600;
+
+    // Set up the tree layout
+    const treeLayout = d3.tree<D3Node>()
+      .size([width - 100, height - 100])
+      .separation((a, b) => (a.parent === b.parent ? 1 : 1.2));
+
+    // Create the hierarchy
+    const root = d3.hierarchy(treeData);
+    treeLayout(root);
+
+    const initialTransform = d3.zoomIdentity.translate(50, 50).scale(1);
+    initialTransformRef.current = initialTransform;
+    let currentZoom = d3.zoomIdentity;
+
+    const container = svg.append('g');
+
+    const zoomBehavior = d3.zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.1, 3])
+      .on('zoom', (event) => {
+        currentZoom = event.transform;
+        container.attr('transform', event.transform);
       });
-      svg.dispatchEvent(wheelEvent);
-      console.log('Triggered synthetic wheel event for zoom out');
-    }
-  };
+
+    zoomBehaviorRef.current = zoomBehavior;
+
+    svg.call(zoomBehavior as any);
+
+    // Apply initial transform
+    svg.call(zoomBehavior.transform as any, initialTransform);
+    currentZoom = initialTransform;
+
+    // Draw links between nodes
+    const links = container.selectAll('.link')
+      .data(root.links())
+      .enter()
+      .append('path')
+      .attr('class', 'link')
+      .attr('d', (d: any) => {
+        const linkGen = d3.linkHorizontal()
+          .x((d: any) => d.x)
+          .y((d: any) => d.y);
+        return linkGen(d);
+      })
+      .attr('fill', 'none')
+      .attr('stroke', '#4F46E5')
+      .attr('stroke-width', 2);
+
+    // Create node groups
+    const nodes = container.selectAll('.node')
+      .data(root.descendants())
+      .enter()
+      .append('g')
+      .attr('class', 'node')
+      .attr('transform', d => `translate(${d.x},${d.y})`);
+
+    // Draw couple cards
+    nodes.each(function(d) {
+      const nodeGroup = d3.select(this);
+      const nodeData = d.data as D3Node;
+      
+      // Draw cards for each partner
+      nodeData.partners.forEach((partner, index) => {
+        const cardGroup = nodeGroup.append('g')
+          .attr('transform', `translate(${index * 200 - (nodeData.partners.length - 1) * 100}, -60)`);
+
+        // Card background
+        cardGroup.append('rect')
+          .attr('width', 180)
+          .attr('height', 120)
+          .attr('rx', 12)
+          .attr('fill', selectedMember?.id === partner.id ? '#EEF2FF' : '#FFFFFF')
+          .attr('stroke', selectedMember?.id === partner.id ? '#6366F1' : '#E5E7EB')
+          .attr('stroke-width', selectedMember?.id === partner.id ? 3 : 1)
+          .style('cursor', 'pointer')
+          .on('click', () => onSelectMember(partner));
+
+        // Partner name
+        cardGroup.append('text')
+          .attr('x', 90)
+          .attr('y', 40)
+          .attr('text-anchor', 'middle')
+          .attr('font-size', 16)
+          .attr('font-weight', 600)
+          .attr('fill', '#1F2937')
+          .text(partner.first_name);
+
+        // Partner last name
+        cardGroup.append('text')
+          .attr('x', 90)
+          .attr('y', 60)
+          .attr('text-anchor', 'middle')
+          .attr('font-size', 14)
+          .attr('fill', '#6B7280')
+          .text(partner.last_name);
+
+        // Gender
+        cardGroup.append('text')
+          .attr('x', 90)
+          .attr('y', 110)
+          .attr('text-anchor', 'middle')
+          .attr('font-size', 12)
+          .attr('fill', '#9CA3AF')
+          .text(partner.gender);
+      });
+
+      // Draw line between partners if it's a couple
+      if (nodeData.partners.length === 2) {
+        nodeGroup.append('line')
+          .attr('x1', -100)
+          .attr('y1', 0)
+          .attr('x2', 100)
+          .attr('y2', 0)
+          .attr('stroke', '#E11D48')
+          .attr('stroke-width', 3);
+      }
+    });
+
+  }, [treeData, selectedMember, onSelectMember]);
 
   return (
-    <div className="family-tree-modal-overlay">
-      <div className="family-tree-modal-content">
-        {/* Close button */}
-        <button 
-          className="family-tree-modal-close-btn" 
-          onClick={props.onClose}
-          aria-label="Close fullscreen family tree"
-        >
-          &times;
-        </button>
-
-        {/* Simplified Navigation Controls */}
-        <div className="family-tree-navigation-controls">
-          {/* Directional Navigation */}
-          <div className="navigation-arrows">
-            <button 
-              className="nav-btn nav-btn-up"
-              onClick={() => handleNavigate('up')}
-              aria-label="Pan up"
-              title="Pan up"
-            >
-              ↑
-            </button>
-            <div className="nav-horizontal">
-              <button 
-                className="nav-btn nav-btn-left"
-                onClick={() => handleNavigate('left')}
-                aria-label="Pan left"
-                title="Pan left"
-              >
-                ←
-              </button>
-              <button 
-                className="nav-btn nav-btn-center"
-                onClick={handleCenterView}
-                aria-label="Center view"
-                title="Center view"
-              >
-                ⌂
-              </button>
-              <button 
-                className="nav-btn nav-btn-right"
-                onClick={() => handleNavigate('right')}
-                aria-label="Pan right"
-                title="Pan right"
-              >
-                →
-              </button>
-            </div>
-            <button 
-              className="nav-btn nav-btn-down"
-              onClick={() => handleNavigate('down')}
-              aria-label="Pan down"
-              title="Pan down"
-            >
-              ↓
-            </button>
-          </div>
-
-          {/* Quick Zoom Controls */}
-          <div className="zoom-controls">
-            <button 
-              className="nav-btn zoom-btn"
-              onClick={handleZoomIn}
-              aria-label="Zoom in"
-              title="Zoom in"
-            >
-              +
-            </button>
-            <button 
-              className="nav-btn zoom-btn"
-              onClick={handleZoomOut}
-              aria-label="Zoom out"
-              title="Zoom out"
-            >
-              −
-            </button>
-          </div>
-        </div>
-
-        {/* Instructions */}
-        <div className="navigation-instructions">
-          Use arrow keys or buttons to pan • +/- buttons for quick zoom • ESC to close
-        </div>
-
-        {/* Family Tree Container */}
-        <div 
-          ref={containerRef}
-          className="family-tree-scrollable-container"
-        >
-          <FamilyTree 
-            {...props} 
-            onCloseTreeView={props.onClose}
-          />
-        </div>
-      </div>
+    <div className="family-tree-container">
+      <svg
+        ref={svgRef}
+        width="100%"
+        height="100vh"
+        style={{ background: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)' }}
+      />
     </div>
   );
-};
+});
 
-export default FamilyTreeModal;
+export default D3FamilyTree; 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import FamilyTree from '../components/FamilyTree';
+import FamilyTreeModal from '../components/FamilyTreeModal'; // Import the modal
 import AddFamilyMemberForm from '../components/AddFamilyMemberForm';
 import AddRelationForm from '../components/AddRelationForm';
 import EditMemberForm from '../components/EditMemberForm';
@@ -20,6 +21,7 @@ const Dashboard: React.FC = () => {
   const [showEditMemberForm, setShowEditMemberForm] = useState(false);
   const [memberToEdit, setMemberToEdit] = useState<FamilyMember | null>(null);
   const [selectedFamilyMember, setSelectedFamilyMember] = useState<FamilyMember | null>(null);
+  const [isFamilyTreeFullscreen, setIsFamilyTreeFullscreen] = useState(false);
 
   // Get the first member created (member with earliest created_at timestamp)
   const firstMember = familyMembers.length > 0 ? familyMembers[0] : null;
@@ -186,6 +188,13 @@ const Dashboard: React.FC = () => {
     }
   };
 
+  // Handle closing fullscreen modal
+  const handleCloseFullscreen = () => {
+    setIsFamilyTreeFullscreen(false);
+    // Optionally clear selection when exiting fullscreen
+    // setSelectedFamilyMember(null);
+  };
+
   if (loading) {
     return (
       <div className="container">
@@ -196,12 +205,37 @@ const Dashboard: React.FC = () => {
 
   return (
     <div className="container">
-      {/* RED BOX TEST - Moved to top */}
+      {/* Fullscreen Modal */}
+      {isFamilyTreeFullscreen && (
+        <FamilyTreeModal
+          familyMembers={familyMembers}
+          relationships={relationships}
+          onDeleteMember={handleDeleteMember}
+          onSelectMember={setSelectedFamilyMember}
+          selectedMember={selectedFamilyMember}
+          onDeleteRelationship={handleDeleteRelationship}
+          onAddMember={() => setShowAddMemberForm(true)}
+          onAddRelatedMember={(member) => {
+            setSelectedFamilyMember(member);
+            setShowAddRelationFormMode('add_new_related');
+          }}
+          onAddExistingRelationship={(member) => {
+            setSelectedFamilyMember(member);
+            setShowAddRelationFormMode('add_existing_relation');
+          }}
+          onEditMember={handleEditMember}
+          onClose={handleCloseFullscreen}
+          firstMember={firstMember}
+          isFullscreen={true}
+        />
+      )}
+
+      {/* Add Relation Form Modal */}
       {showAddRelationFormMode !== 'none' && (
         <div 
           style={{
             position: 'fixed',
-            top: '80px', // Start below the navbar
+            top: '80px',
             left: 0,
             right: 0,
             bottom: 0,
@@ -210,7 +244,7 @@ const Dashboard: React.FC = () => {
             justifyContent: 'center',
             alignItems: 'flex-start',
             paddingTop: '20px',
-            zIndex: 1000
+            zIndex: 1001 // Higher than fullscreen modal
           }}
           onClick={() => setShowAddRelationFormMode('none')}
         >
@@ -274,12 +308,19 @@ const Dashboard: React.FC = () => {
           <button
             onClick={() => {
               setShowAddMemberForm(true);
-              setSelectedFamilyMember(null); // Ensure no member is selected when adding a new one
+              setSelectedFamilyMember(null);
             }}
             className="btn btn-primary"
             style={{ marginRight: '10px' }}
           >
             Add New Family Member
+          </button>
+          <button
+            onClick={() => setIsFamilyTreeFullscreen(true)}
+            className="btn btn-secondary"
+            style={{ marginRight: '10px' }}
+          >
+            Fullscreen Tree
           </button>
 
           {selectedFamilyMember && (
@@ -324,26 +365,26 @@ const Dashboard: React.FC = () => {
             </button>
           </div>
         ) : (
-            <FamilyTree
-              familyMembers={familyMembers}
-              relationships={relationships}
-              onDeleteMember={handleDeleteMember}
-              onSelectMember={setSelectedFamilyMember}
-              selectedMember={selectedFamilyMember}
-              onDeleteRelationship={handleDeleteRelationship}
-              onAddMember={() => setShowAddMemberForm(true)}
-              onAddRelatedMember={(member) => {
-                setSelectedFamilyMember(member);
-                setShowAddRelationFormMode('add_new_related');
-              }}
-              onAddExistingRelationship={(member) => {
-                setSelectedFamilyMember(member);
-                setShowAddRelationFormMode('add_existing_relation');
-              }}
-              onEditMember={handleEditMember}
-              onClosePopup={() => setSelectedFamilyMember(null)}
-              firstMember={firstMember}
-            />
+          <FamilyTree
+            familyMembers={familyMembers}
+            relationships={relationships}
+            onDeleteMember={handleDeleteMember}
+            onSelectMember={setSelectedFamilyMember}
+            selectedMember={selectedFamilyMember}
+            onDeleteRelationship={handleDeleteRelationship}
+            onAddMember={() => setShowAddMemberForm(true)}
+            onAddRelatedMember={(member) => {
+              setSelectedFamilyMember(member);
+              setShowAddRelationFormMode('add_new_related');
+            }}
+            onAddExistingRelationship={(member) => {
+              setSelectedFamilyMember(member);
+              setShowAddRelationFormMode('add_existing_relation');
+            }}
+            onEditMember={handleEditMember}
+            onClosePopup={() => setSelectedFamilyMember(null)}
+            firstMember={firstMember}
+          />
         )}
 
         {familyMembers.length > 0 && (
@@ -375,12 +416,12 @@ const Dashboard: React.FC = () => {
                     >
                       Edit
                     </button>
-                  <button
-                    onClick={() => handleDeleteMember(member.id)}
-                    className="btn btn-danger"
-                  >
-                    Delete
-                  </button>
+                    <button
+                      onClick={() => handleDeleteMember(member.id)}
+                      className="btn btn-danger"
+                    >
+                      Delete
+                    </button>
                   </div>
                 </div>
               ))}
@@ -388,25 +429,12 @@ const Dashboard: React.FC = () => {
           </div>
         )}
 
-        {/* Simple always-visible test */}
-        <div style={{
-          background: 'orange',
-          color: 'black',
-          padding: '15px',
-          margin: '15px 0',
-          border: '3px solid black',
-          fontSize: '16px',
-          fontWeight: 'bold'
-        }}>
-          🧪 ALWAYS VISIBLE TEST - This should always be visible 🧪
-        </div>
-
-        {/* Forms */}
+        {/* Add Member Form Modal */}
         {showAddMemberForm && (
           <div 
             style={{
               position: 'fixed',
-              top: '80px', // Start below the navbar
+              top: '80px',
               left: 0,
               right: 0,
               bottom: 0,
@@ -415,7 +443,7 @@ const Dashboard: React.FC = () => {
               justifyContent: 'center',
               alignItems: 'flex-start',
               paddingTop: '20px',
-              zIndex: 1000
+              zIndex: 1001 // Higher than fullscreen modal
             }}
             onClick={() => setShowAddMemberForm(false)}
           >
@@ -458,145 +486,73 @@ const Dashboard: React.FC = () => {
           </div>
         )}
 
-        {/* MINIMAL TEST - Replace complex form with simple test */}
-        {/*
-        {showAddRelationFormMode !== 'none' && (
-          <div style={{
-            background: 'red',
-            color: 'white',
-            padding: '50px',
-            margin: '20px 0',
-            border: '10px solid yellow',
-            fontSize: '24px',
-            fontWeight: 'bold',
-            textAlign: 'center'
-          }}>
-            🚨 FORM SHOULD BE VISIBLE - MODE: {showAddRelationFormMode} 🚨
-            <br />
-            <button 
+        {/* Edit Member Form Modal */}
+        {showEditMemberForm && memberToEdit && (
+          <div 
+            style={{
+              position: 'fixed',
+              top: '80px',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              background: 'rgba(0, 0, 0, 0.5)',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'flex-start',
+              paddingTop: '20px',
+              zIndex: 1001 // Higher than fullscreen modal
+            }}
+            onClick={() => {
+              setShowEditMemberForm(false);
+              setMemberToEdit(null);
+            }}
+          >
+            <div 
               style={{
                 background: 'white',
-                color: 'red',
-                padding: '10px 20px',
-                border: 'none',
-                borderRadius: '5px',
-                fontSize: '16px',
-                marginTop: '20px',
-                cursor: 'pointer'
+                color: 'black',
+                padding: '20px',
+                border: '2px solid orange',
+                borderRadius: '8px',
+                maxWidth: '500px',
+                width: '90%',
+                maxHeight: 'calc(80vh - 100px)',
+                overflowY: 'auto',
+                boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
               }}
-              onClick={() => {
-                console.log('Close button clicked');
-                setShowAddRelationFormMode('none');
-              }}
+              onClick={(e) => e.stopPropagation()}
             >
-              CLOSE THIS TEST
-            </button>
-          </div>
-        )}
-        */}
-
-        {/* Original complex form - commented out for now */}
-        {/*
-        {showAddRelationFormMode !== 'none' && (
-          <div style={{ 
-            border: '3px solid blue', 
-            padding: '10px', 
-            margin: '10px 0',
-            background: '#d1ecf1'
-          }}>
-            <h3 style={{ color: 'blue' }}>ADD RELATION FORM IS RENDERED - Mode: {showAddRelationFormMode}</h3>
-            <div style={{
-              background: 'lime',
-              color: 'black',
-              padding: '20px',
-              margin: '10px 0',
-              border: '5px solid black',
-              fontSize: '20px',
-              fontWeight: 'bold'
-            }}>
-              🎯 FORM CONTAINER IS VISIBLE - MODE: {showAddRelationFormMode} 🎯
-            </div>
-            
-            <div style={{
-              background: 'white',
-              border: '2px solid purple',
-              padding: '20px',
-              margin: '10px 0',
-              borderRadius: '8px'
-            }}>
-              <h4 style={{ color: 'purple', margin: '0 0 15px 0' }}>SIMPLE TEST FORM</h4>
-              <p style={{ margin: '10px 0' }}>This is a test form to see if forms are visible at all.</p>
-              <input 
-                type="text" 
-                placeholder="Test input field" 
-                style={{
-                  width: '100%',
-                  padding: '10px',
-                  border: '1px solid #ccc',
-                  borderRadius: '4px',
-                  margin: '10px 0'
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '15px' }}>
+                <h3 style={{ color: 'orange', margin: 0, fontSize: '18px' }}>Edit Family Member</h3>
+                <button 
+                  onClick={() => {
+                    setShowEditMemberForm(false);
+                    setMemberToEdit(null);
+                  }}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    fontSize: '20px',
+                    cursor: 'pointer',
+                    color: '#666',
+                    padding: '5px'
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+              <EditMemberForm
+                member={memberToEdit}
+                onMemberUpdated={handleMemberUpdated}
+                onCancel={() => {
+                  setShowEditMemberForm(false);
+                  setMemberToEdit(null);
                 }}
               />
-              <button 
-                style={{
-                  background: 'purple',
-                  color: 'white',
-                  padding: '10px 20px',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  margin: '10px 5px 10px 0'
-                }}
-                onClick={() => console.log('Test button clicked')}
-              >
-                Test Button
-              </button>
-              <button 
-                style={{
-                  background: 'gray',
-                  color: 'white',
-                  padding: '10px 20px',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer'
-                }}
-                onClick={() => setShowAddRelationFormMode('none')}
-              >
-                Close Test
-              </button>
             </div>
-            
-            <AddRelationForm
-              mode={showAddRelationFormMode}
-              selectedFamilyMember={selectedFamilyMember}
-              familyMembers={familyMembers}
-              existingRelationships={relationships}
-              onRelationAdded={handleRelationAdded}
-              onCancel={() => setShowAddRelationFormMode('none')}
-            />
           </div>
         )}
-        */}
-
-        {showEditMemberForm && memberToEdit && (
-          <div style={{ 
-            border: '3px solid green', 
-            padding: '10px', 
-            margin: '10px 0',
-            background: '#d4edda'
-          }}>
-            <h3 style={{ color: 'green' }}>EDIT MEMBER FORM IS RENDERED</h3>
-            <EditMemberForm
-              member={memberToEdit}
-              onMemberUpdated={handleMemberUpdated}
-              onCancel={() => {
-                setShowEditMemberForm(false);
-                setMemberToEdit(null);
-              }}
-            />
-          </div>
-        )}
-        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Summary
This commit improves the consistency and reliability of zoom and pan interactions in the family tree view. It unifies the internal and external control mechanisms for keyboard navigation and zoom buttons, ensuring that all user interactions (mouse, buttons, or keyboard) produce consistent visual updates.

### Changes
- ✅ Implemented �pplyZoomFactor(factor) utility in FamilyTree.tsx to standardize zoom logic across internal buttons and external triggers.
- ✅ Updated internal Zoom In/Out buttons to use �pplyZoomFactor, ensuring shared behavior with modal zoom buttons.
- ✅ Connected externalZoom prop from FamilyTreeModal to zoom state in FamilyTree via a new useEffect.
- ✅ Improved externalPan handling by using useEffect with [externalPan?.dx, externalPan?.dy] as dependencies to guarantee the pan effect is triggered correctly, even with quick state resets.
- ✅ Added console logs in both modal and tree for debugging keyboard-triggered navigation.
- ✅ Verified compatibility with both mouse and keyboard navigation (Arrow keys) inside modal view.

### Impact
Users can now zoom and pan the family tree consistently using:
- Mouse wheel
- Internal Zoom In/Out buttons
- Modal buttons
- Keyboard Arrow keys

This resolves prior issues where zooming and panning via external modal controls had no visible effect on the tree view.