### PR TITLE
When the fullscreen modal opens, the browser was auto-focusing a butt…

### DIFF
--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -919,7 +919,7 @@ const FamilyTree: React.FC<FamilyTreeProps> = ({
           node.children.length >= 2 &&                    // Has multiple children
           node.siblings.length === 0 &&                   // No siblings  
           node.spouses.length === 0 &&                    // No spouses
-          node.children.every(child =>                     // All children have siblings (form a sibling group)
+          node.children.every(child =>                    // All children have siblings (form a sibling group)
             child.siblings.length > 0 ||
             node.children.length > 1  // OR this parent has multiple children (making them siblings)
           )

--- a/src/components/FamilyTreeModal.tsx
+++ b/src/components/FamilyTreeModal.tsx
@@ -46,11 +46,12 @@ const FamilyTreeModal: React.FC<FamilyTreeModalProps> = ({
       }
       // Add keyboard navigation: only if not focused on an input/button
       const activeElement = document.activeElement;
-      const isInputFocused = activeElement && (
-        activeElement.tagName === 'INPUT' ||
-        activeElement.tagName === 'BUTTON' ||
-        activeElement.tagName === 'TEXTAREA'
-      );
+      const isInputFocused =
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          (activeElement as HTMLElement).isContentEditable === true
+        );
 
       if (!isInputFocused) {
         if (event.key === 'ArrowLeft') {
@@ -112,7 +113,7 @@ const FamilyTreeModal: React.FC<FamilyTreeModalProps> = ({
 
   const triggerZoomEvent = (factor: number) => {
     setExternalZoom(factor);
-    
+
     // Reset after a tick to avoid re-triggering
     setTimeout(() => {
       setExternalZoom(null);


### PR DESCRIPTION
…on in the modal (very likely the close '×' or one of the nav buttons).  Skipping arrow-key navigation whenever an input/button/textarea has focus, so the arrows do nothing until you click a member card (which moves focus away). Now it works always